### PR TITLE
Fix configuration of ResponseCachingOptions

### DIFF
--- a/DistributedResponseCachingMiddleware/Custom/CustomResponseCachingServiceExtensions.cs
+++ b/DistributedResponseCachingMiddleware/Custom/CustomResponseCachingServiceExtensions.cs
@@ -48,7 +48,15 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var options = new CustomResponseCachingOptions();
             configureOptions(options);
+
             services.Configure(configureOptions);
+            services.Configure<ResponseCachingOptions>(baseOptions =>
+            {
+                baseOptions.SizeLimit = options.SizeLimit;
+                baseOptions.MaximumBodySize = options.MaximumBodySize;
+                baseOptions.UseCaseSensitivePaths = options.UseCaseSensitivePaths;
+                baseOptions.SystemClock = options.SystemClock;
+            });
 
             _ = options.ResponseCachingStrategy switch
             {


### PR DESCRIPTION
Fix configuration of ResponseCachingOptions by configuring it explicitly. By just registering the CustomResponseCachingOptions, the options of the base objects would get lost when resolving for IOptions<ResponseCachingOptions>.